### PR TITLE
made it so that when cody resets heading the bot will no longer use a…

### DIFF
--- a/src/main/java/frc/robot/commands/Chassis/ZeroEverything.java
+++ b/src/main/java/frc/robot/commands/Chassis/ZeroEverything.java
@@ -33,6 +33,8 @@ public class ZeroEverything extends InstantCommand {
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
+    // if you were right, and you tell it you are somewhere else, then you will be wrong
+    m_chassis.setAprilTagUsage(false); 
     m_chassis.resetOdometry(new Pose2d(0, 0, new Rotation2d()));
   }
 }


### PR DESCRIPTION
…pril tags

This commit makes it so that april tags odometry will be off when cody hits the reset heading button. It is not a toggle. It will then brake any automatically go to a certain position commands.